### PR TITLE
Removing the overwrite of Base.convert, creating a new function instead

### DIFF
--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -26,5 +26,5 @@ mutable struct ModelSetup{T<:AbstractFloat,Tprog<:AbstractFloat}
     forcing::Forcing{T}
     Prog::PrognosticVars{Tprog}
     Diag::DiagnosticVars{T, Tprog}
-    t::Int                              # SW: I believe this has something to do with Checkpointing, need to verify
+    t::Int
 end

--- a/src/time_integration.jl
+++ b/src/time_integration.jl
@@ -131,8 +131,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs .= Diag.PrognosticVarsRHS.u .= u1
-                v1rhs .= Diag.PrognosticVarsRHS.v .= v1
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
 
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 axb!(η1,Δt_Δs,dη)       # η1 = η1 + Δt/(s-1)*RHS(u1)
@@ -181,8 +181,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs .= Diag.PrognosticVarsRHS.u .= u1
-                v1rhs .= Diag.PrognosticVarsRHS.v .= v1
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
 
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -227,8 +227,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 # semi-implicit for continuity equation, use u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
 
-                u1rhs .= Diag.PrognosticVarsRHS.u .= u1
-                v1rhs .= Diag.PrognosticVarsRHS.v .= v1
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
 
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 
@@ -275,8 +275,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         t += dtint
 
         # TRACER ADVECTION
-        u0rhs .= Diag.PrognosticVarsRHS.u .= u0
-        v0rhs .= Diag.PrognosticVarsRHS.v .= v0
+        u0rhs = Diag.PrognosticVarsRHS.u .= u0
+        v0rhs = Diag.PrognosticVarsRHS.v .= v0
 
         tracer!(i,u0rhs,v0rhs,Prog,Diag,S)
 
@@ -398,24 +398,3 @@ function dxaybzc!(  d::Array{T,2},
         end
     end
 end
-
-# """Convert function for two arrays, X1, X2, in case their eltypes differ.
-# Convert every element from X1 and store it in X2."""
-# function mixprec_convert(X2::Array{T2,N},X1::Array{T1,N}) where {T1,T2,N}
-
-#     @boundscheck size(X2) == size(X1) || throw(BoundsError())
-
-#     @inbounds for i in eachindex(X1)
-#             X2[i] = convert(T2,X1[i])
-#     end
-
-#     return X2
-# end
-
-
-# """Convert function for two arrays, X1, X2, in case their eltypes are identical.
-# Just pass X1, such that X2 is pointed to the same place in memory."""
-# function mixprec_convert(X2::Array{T,N},X1::Array{T,N}) where {T,N}
-#     @boundscheck size(X2) == size(X1) || throw(BoundsError())
-#     return X1
-# end

--- a/src/time_integration.jl
+++ b/src/time_integration.jl
@@ -72,12 +72,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs = Diag.PrognosticVarsRHS.u
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs = Diag.PrognosticVarsRHS.v
-                Diag.PrognosticVarsRHS.η .= η1
-                η1rhs = Diag.PrognosticVarsRHS.η
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
+                η1rhs = Diag.PrognosticVarsRHS.η .= η1
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)          # momentum only
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)   # continuity equation 
@@ -122,12 +119,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs = Diag.PrognosticVarsRHS.u
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs = Diag.PrognosticVarsRHS.v
-                Diag.PrognosticVarsRHS.η .= η1
-                η1rhs = Diag.PrognosticVarsRHS.η
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
+                η1rhs = Diag.PrognosticVarsRHS.η .= η1
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)        # momentum only
 
@@ -137,10 +131,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs .= Diag.PrognosticVarsRHS.u
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs .= Diag.PrognosticVarsRHS.v
+                u1rhs .= Diag.PrognosticVarsRHS.u .= u1
+                v1rhs .= Diag.PrognosticVarsRHS.v .= v1
 
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 axb!(η1,Δt_Δs,dη)       # η1 = η1 + Δt/(s-1)*RHS(u1)
@@ -168,12 +160,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs = Diag.PrognosticVarsRHS.u
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs = Diag.PrognosticVarsRHS.v
-                Diag.PrognosticVarsRHS.η .= η1
-                η1rhs = Diag.PrognosticVarsRHS.η
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
+                η1rhs = Diag.PrognosticVarsRHS.η .= η1
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -192,10 +181,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs .= Diag.PrognosticVarsRHS.u
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs .= Diag.PrognosticVarsRHS.v
+                u1rhs .= Diag.PrognosticVarsRHS.u .= u1
+                v1rhs .= Diag.PrognosticVarsRHS.v .= v1
 
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -226,14 +213,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs = Diag.PrognosticVarsRHS.u
-
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs = Diag.PrognosticVarsRHS.v
-
-                Diag.PrognosticVarsRHS.η .= η1
-                η1rhs = Diag.PrognosticVarsRHS.η
+                u1rhs = Diag.PrognosticVarsRHS.u .= u1
+                v1rhs = Diag.PrognosticVarsRHS.v .= v1
+                η1rhs = Diag.PrognosticVarsRHS.η .= η1
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -245,10 +227,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 # semi-implicit for continuity equation, use u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
 
-                Diag.PrognosticVarsRHS.u .= u1
-                u1rhs .= Diag.PrognosticVarsRHS.u
-                Diag.PrognosticVarsRHS.v .= v1
-                v1rhs .= Diag.PrognosticVarsRHS.v
+                u1rhs .= Diag.PrognosticVarsRHS.u .= u1
+                v1rhs .= Diag.PrognosticVarsRHS.v .= v1
 
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 
@@ -270,12 +250,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         ghost_points!(u0,v0,η0,S)
 
         # type conversion for mixed precision
-        Diag.PrognosticVarsRHS.u .= u0
-        u0rhs = Diag.PrognosticVarsRHS.u
-        Diag.PrognosticVarsRHS.v .= v0
-        v0rhs = Diag.PrognosticVarsRHS.v
-        Diag.PrognosticVarsRHS.η .= η0
-        η0rhs = Diag.PrognosticVarsRHS.η
+        u0rhs = Diag.PrognosticVarsRHS.u .= u0
+        v0rhs = Diag.PrognosticVarsRHS.v .= v0
+        η0rhs = Diag.PrognosticVarsRHS.η .= η0
 
         # ADVECTION and CORIOLIS TERMS
         # although included in the tendency of every RK substep,
@@ -298,10 +275,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         t += dtint
 
         # TRACER ADVECTION
-        Diag.PrognosticVarsRHS.u .= u0
-        u0rhs .= Diag.PrognosticVarsRHS.u
-        Diag.PrognosticVarsRHS.v .= v0
-        v0rhs .= Diag.PrognosticVarsRHS.v
+        u0rhs .= Diag.PrognosticVarsRHS.u .= u0
+        v0rhs .= Diag.PrognosticVarsRHS.v .= v0
 
         tracer!(i,u0rhs,v0rhs,Prog,Diag,S)
 

--- a/src/time_integration.jl
+++ b/src/time_integration.jl
@@ -28,12 +28,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
     Ixy!(Diag.Vorticity.h_q,Diag.VolumeFluxes.h)
 
     # calculate PV terms for initial conditions
-    Diag.PrognosticVarsRHS.u .= u
-    urhs = Diag.PrognosticVarsRHS.u
-    Diag.PrognosticVarsRHS.v .= v
-    vrhs = Diag.PrognosticVarsRHS.v
-    Diag.PrognosticVarsRHS.η .= η
-    ηrhs = Diag.PrognosticVarsRHS.η
+    urhs = Diag.PrognosticVarsRHS.u .= u
+    vrhs = Diag.PrognosticVarsRHS.v .= v
+    ηrhs = Diag.PrognosticVarsRHS.η .= η
 
     advection_coriolis!(urhs,vrhs,ηrhs,Diag,S)
     PVadvection!(Diag,S)

--- a/src/time_integration.jl
+++ b/src/time_integration.jl
@@ -28,9 +28,13 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
     Ixy!(Diag.Vorticity.h_q,Diag.VolumeFluxes.h)
 
     # calculate PV terms for initial conditions
-    urhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u)
-    vrhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v)
-    ηrhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η)
+    Diag.PrognosticVarsRHS.u .= u
+    urhs = Diag.PrognosticVarsRHS.u
+    Diag.PrognosticVarsRHS.v .= v
+    vrhs = Diag.PrognosticVarsRHS.v
+    Diag.PrognosticVarsRHS.η .= η
+    ηrhs = Diag.PrognosticVarsRHS.η
+
     advection_coriolis!(urhs,vrhs,ηrhs,Diag,S)
     PVadvection!(Diag,S)
 
@@ -71,9 +75,12 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs = Diag.PrognosticVarsRHS.u
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs = Diag.PrognosticVarsRHS.v
+                Diag.PrognosticVarsRHS.η .= η1
+                η1rhs = Diag.PrognosticVarsRHS.η
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)          # momentum only
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)   # continuity equation 
@@ -118,9 +125,12 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs = Diag.PrognosticVarsRHS.u
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs = Diag.PrognosticVarsRHS.v
+                Diag.PrognosticVarsRHS.η .= η1
+                η1rhs = Diag.PrognosticVarsRHS.η
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)        # momentum only
 
@@ -130,8 +140,11 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs .= Diag.PrognosticVarsRHS.u
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs .= Diag.PrognosticVarsRHS.v
+
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 axb!(η1,Δt_Δs,dη)       # η1 = η1 + Δt/(s-1)*RHS(u1)
             end
@@ -158,9 +171,12 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs = Diag.PrognosticVarsRHS.u
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs = Diag.PrognosticVarsRHS.v
+                Diag.PrognosticVarsRHS.η .= η1
+                η1rhs = Diag.PrognosticVarsRHS.η
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -179,8 +195,11 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs .= Diag.PrognosticVarsRHS.u
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs .= Diag.PrognosticVarsRHS.v
+
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
                 if rki == kn
@@ -210,9 +229,14 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs = Diag.PrognosticVarsRHS.u
+
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs = Diag.PrognosticVarsRHS.v
+
+                Diag.PrognosticVarsRHS.η .= η1
+                η1rhs = Diag.PrognosticVarsRHS.η
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -223,8 +247,12 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+
+                Diag.PrognosticVarsRHS.u .= u1
+                u1rhs .= Diag.PrognosticVarsRHS.u
+                Diag.PrognosticVarsRHS.v .= v1
+                v1rhs .= Diag.PrognosticVarsRHS.v
+
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 
                 caxb!(η0,η1,Δt_Δ,dη)    # store Euler update into η0
@@ -245,9 +273,12 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         ghost_points!(u0,v0,η0,S)
 
         # type conversion for mixed precision
-        u0rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u0)
-        v0rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v0)
-        η0rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η0)
+        Diag.PrognosticVarsRHS.u .= u0
+        u0rhs = Diag.PrognosticVarsRHS.u
+        Diag.PrognosticVarsRHS.v .= v0
+        v0rhs = Diag.PrognosticVarsRHS.v
+        Diag.PrognosticVarsRHS.η .= η0
+        η0rhs = Diag.PrognosticVarsRHS.η
 
         # ADVECTION and CORIOLIS TERMS
         # although included in the tendency of every RK substep,
@@ -270,8 +301,11 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         t += dtint
 
         # TRACER ADVECTION
-        u0rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u0)  # copy back as add_drag_diff_tendencies changed u0,v0
-        v0rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v0)
+        Diag.PrognosticVarsRHS.u .= u0
+        u0rhs .= Diag.PrognosticVarsRHS.u
+        Diag.PrognosticVarsRHS.v .= v0
+        v0rhs .= Diag.PrognosticVarsRHS.v
+
         tracer!(i,u0rhs,v0rhs,Prog,Diag,S)
 
         # feedback and output
@@ -393,23 +427,23 @@ function dxaybzc!(  d::Array{T,2},
     end
 end
 
-"""Convert function for two arrays, X1, X2, in case their eltypes differ.
-Convert every element from X1 and store it in X2."""
-function mixprec_convert(X2::Array{T2,N},X1::Array{T1,N}) where {T1,T2,N}
+# """Convert function for two arrays, X1, X2, in case their eltypes differ.
+# Convert every element from X1 and store it in X2."""
+# function mixprec_convert(X2::Array{T2,N},X1::Array{T1,N}) where {T1,T2,N}
 
-    @boundscheck size(X2) == size(X1) || throw(BoundsError())
+#     @boundscheck size(X2) == size(X1) || throw(BoundsError())
 
-    @inbounds for i in eachindex(X1)
-            X2[i] = convert(T2,X1[i])
-    end
+#     @inbounds for i in eachindex(X1)
+#             X2[i] = convert(T2,X1[i])
+#     end
 
-    return X2
-end
+#     return X2
+# end
 
 
-"""Convert function for two arrays, X1, X2, in case their eltypes are identical.
-Just pass X1, such that X2 is pointed to the same place in memory."""
-function mixprec_convert(X2::Array{T,N},X1::Array{T,N}) where {T,N}
-    @boundscheck size(X2) == size(X1) || throw(BoundsError())
-    return X1
-end
+# """Convert function for two arrays, X1, X2, in case their eltypes are identical.
+# Just pass X1, such that X2 is pointed to the same place in memory."""
+# function mixprec_convert(X2::Array{T,N},X1::Array{T,N}) where {T,N}
+#     @boundscheck size(X2) == size(X1) || throw(BoundsError())
+#     return X1
+# end

--- a/src/time_integration.jl
+++ b/src/time_integration.jl
@@ -28,9 +28,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
     Ixy!(Diag.Vorticity.h_q,Diag.VolumeFluxes.h)
 
     # calculate PV terms for initial conditions
-    urhs = convert(Diag.PrognosticVarsRHS.u,u)
-    vrhs = convert(Diag.PrognosticVarsRHS.v,v)
-    ηrhs = convert(Diag.PrognosticVarsRHS.η,η)
+    urhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u)
+    vrhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v)
+    ηrhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η)
     advection_coriolis!(urhs,vrhs,ηrhs,Diag,S)
     PVadvection!(Diag,S)
 
@@ -71,9 +71,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = convert(Diag.PrognosticVarsRHS.η,η1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)          # momentum only
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)   # continuity equation 
@@ -118,9 +118,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = convert(Diag.PrognosticVarsRHS.η,η1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)        # momentum only
 
@@ -130,8 +130,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 axb!(η1,Δt_Δs,dη)       # η1 = η1 + Δt/(s-1)*RHS(u1)
             end
@@ -158,9 +158,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = convert(Diag.PrognosticVarsRHS.η,η1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -179,8 +179,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use new u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
                 if rki == kn
@@ -210,9 +210,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
                 end
 
                 # type conversion for mixed precision
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
-                η1rhs = convert(Diag.PrognosticVarsRHS.η,η1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
+                η1rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η1)
 
                 rhs!(u1rhs,v1rhs,η1rhs,Diag,S,t)
 
@@ -223,8 +223,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
 
                 # semi-implicit for continuity equation, use u1,v1 to calcualte dη
                 ghost_points_uv!(u1,v1,S)
-                u1rhs = convert(Diag.PrognosticVarsRHS.u,u1)
-                v1rhs = convert(Diag.PrognosticVarsRHS.v,v1)
+                u1rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u1)
+                v1rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v1)
                 continuity!(u1rhs,v1rhs,η1rhs,Diag,S,t)
                 
                 caxb!(η0,η1,Δt_Δ,dη)    # store Euler update into η0
@@ -245,9 +245,9 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         ghost_points!(u0,v0,η0,S)
 
         # type conversion for mixed precision
-        u0rhs = convert(Diag.PrognosticVarsRHS.u,u0)
-        v0rhs = convert(Diag.PrognosticVarsRHS.v,v0)
-        η0rhs = convert(Diag.PrognosticVarsRHS.η,η0)
+        u0rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u0)
+        v0rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v0)
+        η0rhs = mixprec_convert(Diag.PrognosticVarsRHS.η,η0)
 
         # ADVECTION and CORIOLIS TERMS
         # although included in the tendency of every RK substep,
@@ -270,8 +270,8 @@ function time_integration(S::ModelSetup{T,Tprog}) where {T<:AbstractFloat,Tprog<
         t += dtint
 
         # TRACER ADVECTION
-        u0rhs = convert(Diag.PrognosticVarsRHS.u,u0)  # copy back as add_drag_diff_tendencies changed u0,v0
-        v0rhs = convert(Diag.PrognosticVarsRHS.v,v0)
+        u0rhs = mixprec_convert(Diag.PrognosticVarsRHS.u,u0)  # copy back as add_drag_diff_tendencies changed u0,v0
+        v0rhs = mixprec_convert(Diag.PrognosticVarsRHS.v,v0)
         tracer!(i,u0rhs,v0rhs,Prog,Diag,S)
 
         # feedback and output
@@ -395,7 +395,7 @@ end
 
 """Convert function for two arrays, X1, X2, in case their eltypes differ.
 Convert every element from X1 and store it in X2."""
-function Base.convert(X2::Array{T2,N},X1::Array{T1,N}) where {T1,T2,N}
+function mixprec_convert(X2::Array{T2,N},X1::Array{T1,N}) where {T1,T2,N}
 
     @boundscheck size(X2) == size(X1) || throw(BoundsError())
 
@@ -409,7 +409,7 @@ end
 
 """Convert function for two arrays, X1, X2, in case their eltypes are identical.
 Just pass X1, such that X2 is pointed to the same place in memory."""
-function Base.convert(X2::Array{T,N},X1::Array{T,N}) where {T,N}
+function mixprec_convert(X2::Array{T,N},X1::Array{T,N}) where {T,N}
     @boundscheck size(X2) == size(X1) || throw(BoundsError())
     return X1
 end

--- a/src/tracer_advection.jl
+++ b/src/tracer_advection.jl
@@ -23,7 +23,7 @@ function tracer!(   i::Integer,
         @unpack ssti,sst_ref,dsst_comp = Diag.SemiLagrange
 
         # convert to type T for mixed precision
-        sstrhs = convert(Diag.PrognosticVarsRHS.sst,sst)
+        sstrhs = mixprec_convert(Diag.PrognosticVarsRHS.sst,sst)
 
         departure!(u,v,Diag,S)
         adv_sst!(sstrhs,Diag,S)

--- a/src/tracer_advection.jl
+++ b/src/tracer_advection.jl
@@ -23,8 +23,7 @@ function tracer!(   i::Integer,
         @unpack ssti,sst_ref,dsst_comp = Diag.SemiLagrange
 
         # convert to type T for mixed precision
-        Diag.PrognosticVarsRHS.sst .= sst
-        sstrhs = Diag.PrognosticVarsRHS.sst
+        sstrhs = Diag.PrognosticVarsRHS.sst .= sst
 
         departure!(u,v,Diag,S)
         adv_sst!(sstrhs,Diag,S)

--- a/src/tracer_advection.jl
+++ b/src/tracer_advection.jl
@@ -23,7 +23,8 @@ function tracer!(   i::Integer,
         @unpack ssti,sst_ref,dsst_comp = Diag.SemiLagrange
 
         # convert to type T for mixed precision
-        sstrhs = mixprec_convert(Diag.PrognosticVarsRHS.sst,sst)
+        Diag.PrognosticVarsRHS.sst .= sst
+        sstrhs = Diag.PrognosticVarsRHS.sst
 
         departure!(u,v,Diag,S)
         adv_sst!(sstrhs,Diag,S)


### PR DESCRIPTION
In `time_integration.jl` there was an overwrite of `Base.convert` to do something different in this code. This might be causing errors with Enzyme.jl/Checkpointing.jl/etc. so I renamed the function to `mixprec_convert` (it does the same thing as it used to) and replaced all instances that called the old convert